### PR TITLE
Change the relative URL of the media Kit for absoulte

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -58,7 +58,7 @@ EVENTO = {
     'submissao':'https://pretalx.com/python-brasil-2023/cfp',
     'data_evento': 'DE 30 OUTUBRO À 05 NOVEMBRO',
     'cidade': 'Caxias do Sul, RS',
-    'kit_divulgacao': '/theme/media_kits/frame.zip'
+    'kit_divulgacao': 'https://github.com/pythonbrasil/pybr2023-site/raw/master/theme/static/media_kits/frames.zip'
 }
 
 PLANOS = {


### PR DESCRIPTION
Since the site will be hosted with 2023.pythonbrasil.com.br this will make the relative links have it as root, and seens as the media kit for attendees are not get correctly linked in public, this will add the absolute link for raw file in GH.