### PR TITLE
Fix link participantes

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -58,7 +58,7 @@ EVENTO = {
     'submissao':'https://pretalx.com/python-brasil-2023/cfp',
     'data_evento': 'DE 30 OUTUBRO À 05 NOVEMBRO',
     'cidade': 'Caxias do Sul, RS',
-    'kit_divulgacao': '/theme/media_kits/frame.zip'
+    'kit_divulgacao': 'https://github.com/pythonbrasil/pybr2023-site/raw/master/theme/static/media_kits/frames.zip'
 }
 
 PLANOS = {

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -58,7 +58,7 @@ EVENTO = {
     'submissao':'https://pretalx.com/python-brasil-2023/cfp',
     'data_evento': 'DE 30 OUTUBRO À 05 NOVEMBRO',
     'cidade': 'Caxias do Sul, RS',
-    'kit_divulgacao': 'https://github.com/pythonbrasil/pybr2023-site/raw/master/theme/static/media_kits/frames.zip'
+    'kit_divulgacao': '/theme/media_kits/frames.zip'
 }
 
 PLANOS = {


### PR DESCRIPTION
Notei que esse arquivo estava caindo em um 404 do GitHub, inicialmente achei que fosse algum problema do Pelican para ter esse arquivo como público, por isso o primeiro commit adicionava ele como link absoluto para o arquivo direto no GH. Porém, percebi pelo diff que na verdade o arquivo estava com nome errado no link e então voltei para um link relativo e mudei o nome para o nome correto do arquivo.

Isso deve resolver.